### PR TITLE
Add style equality functions to the RuleUtils type

### DIFF
--- a/.changeset/silver-gorillas-breathe.md
+++ b/.changeset/silver-gorillas-breathe.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-assistant-types': minor
+---
+
+New function types for style equality comparison were added to the RuleUtils type

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,22 @@ export type RuleUtils = {
    * Resolve a JSON Pointer to a document object’s parent.
    */
   parent: (pointer: string) => Maybe<PointerValue>
+  /**
+   * Compares two style objects for equality.
+   */
+  styleEq: (s1: FileFormat3.Style | undefined, s2: FileFormat3.Style | undefined) => boolean
+  /**
+   * Compares two text style objects for equality.
+   */
+  textStyleEq: (s1: FileFormat3.Style | undefined, s2: FileFormat3.Style | undefined) => boolean
+  /**
+   * Reduces a text style object into a string hash and returns it.
+   */
+  textStyleHash: (style: Partial<FileFormat3.Style> | undefined) => string
+  /**
+   * Reduces a style object into a string hash and returns it.
+   */
+  styleHash: (style: Partial<FileFormat3.Style> | undefined) => string
 }
 
 /**


### PR DESCRIPTION
Style equality types and functions were added.

They made their way into the RuleUtils object.

These types are associated with the refactor being done at:

https://github.com/sketch-hq/sketch-assistant-core-rules/issues/112